### PR TITLE
feat(css): add highlighting via comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The [language-babel](https://github.com/gandm/language-babel) package by [gandm]
    - gql`This is how Apollo for GraphQL uses template strings`
    - /* GraphQL */`For cases where no template tag function is available`
    ```
- - [styled-components](https://github.com/styled-components/styled-components) CSS inside tagged template strings.
+ - [styled-components](https://github.com/styled-components/styled-components), [emotion](https://github.com/emotion-js/emotion) CSS inside tagged template strings plus additional highlighting via `/* CSS */` comment
 
  ## Comparison to Sublime Babel
  See [#1](https://github.com/mgmcdermott/vscode-language-babel/issues/1)

--- a/grammars/Babel-Language.json
+++ b/grammars/Babel-Language.json
@@ -1548,7 +1548,7 @@
           "comment": "Styled CSS tags",
           "contentName": "source.inside-js.css.styled",
           "begin":
-            "\\s*+(?:(?:\\b(css|injectGlobal|keyframes)\\b)|(?:(\\bstyled)(?:(?:(\\?\\.)|(\\.))\\s*(\\w+))))\\s*((`))",
+            "\\s*+(?:(?:\\b(css|injectGlobal|keyframes)\\b)|(?:(\\bstyled)(?:(?:(\\?\\.)|(\\.))\\s*(\\w+)))|(/\\* CSS \\*/))\\s*((`))",
           "end": "\\s*((`))",
           "beginCaptures": {
             "1": {

--- a/test.js
+++ b/test.js
@@ -2,6 +2,13 @@ import React from 'react';
 import styled from 'styled-components';
 import { createFragmentContainer, graphql } from 'react-relay';
 
+const bitsForInjectGlobal = /* CSS */`
+  body {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+`;
 const StyledComponent = styled.div`
   text-align: center; /* Actual CSS highlighting! */
 `;


### PR DESCRIPTION
I've added support for additional css highlighting via `/* CSS */` comments.

Could be useful in situations like this: 

![csscomments](https://user-images.githubusercontent.com/30002276/38262576-4ac407a2-3776-11e8-8908-b0e1839b9ea5.png)
