### PR TITLE
Change the scopeName of javascriptreact to "source.js"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
           "jsx"
         ],
         "extensions": [
-          ".jsx"
+          ".jsx",
+          ".js"
         ],
         "configuration": "./javascript.language-configuration.json"
       },
@@ -75,7 +76,7 @@
     "grammars": [
       {
         "language": "javascriptreact",
-        "scopeName": "source.js.jsx",
+        "scopeName": "source.js",
         "path": "./grammars/Babel-Language.json",
         "embeddedLanguages": {
           "meta.tag.jsx": "jsx",


### PR DESCRIPTION
Because of 74258ca the scopeName `source.js.jsx` doesn't exist anymore so to make #30 work we need to map the `javascriptreact` grammar to `source.js`.

Also, added the extension `.js` to the language identifier so it can work with js files that have `Javascript React` as the language id. too.