### PR TITLE
Add support for createGlobalStyle in styled-components

### DIFF
--- a/grammars/Babel-Language.json
+++ b/grammars/Babel-Language.json
@@ -1548,7 +1548,7 @@
           "comment": "Styled CSS tags",
           "contentName": "source.inside-js.css.styled",
           "begin":
-            "\\s*+(?:(?:\\b(css|injectGlobal|keyframes)\\b)|(?:(\\bstyled)(?:(?:(\\?\\.)|(\\.))\\s*(\\w+)))|(/\\* CSS \\*/))\\s*((`))",
+            "\\s*+(?:(?:\\b(css|injectGlobal|keyframes|createGlobalStyle)\\b)|(?:(\\bstyled)(?:(?:(\\?\\.)|(\\.))\\s*(\\w+)))|(/\\* CSS \\*/))\\s*((`))",
           "end": "\\s*((`))",
           "beginCaptures": {
             "1": {


### PR DESCRIPTION
Version 4 of styled-components introduces a new createGlobalStyle function which currently doesn't get picked up by vscode-language-babel (https://www.styled-components.com/docs/api#createglobalstyle). This PR adds support for it.