### PR TITLE
Prevent ternary operator from incorrectly matching a nullcoalesce

### DIFF
--- a/grammars/Babel-Language.json
+++ b/grammars/Babel-Language.json
@@ -2086,7 +2086,7 @@
         },
         {
           "comment": "ternary operator - make sure end : is consumed to avoid mistake as flow type",
-          "begin": "\\s*+(\\?)(?!\\.[^\\d])",
+          "begin": "\\s*+(\\?)(?!\\.[^\\d]|\\?)",
           "end": "\\s*(:)((?=::)|(?!:))",
           "beginCaptures": {
             "1": {


### PR DESCRIPTION
Small tweak to the ternary regex to make sure it doesn't match `??` which is used for nullcoalesce.

## Before
![image](https://user-images.githubusercontent.com/721323/58629731-a3189480-8320-11e9-9d19-927ace35678e.png)

You can see syntax highlighting is broken after the `??`.

## After
![image](https://user-images.githubusercontent.com/721323/58629747-a9a70c00-8320-11e9-8333-15996c2ce18d.png)