### PR TITLE
Fix highlighting of function calls with Flow type args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-.vscode
+.vscode/*
+!.vscode/tasks.json
+!.vscode/launch.json
 .DS_Store
 .vimrc
 tags

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"]
+    }
+  ]
+}

--- a/grammars/Babel-Language.json
+++ b/grammars/Babel-Language.json
@@ -741,6 +741,30 @@
         }
       ]
     },
+    "type-argument-brackets": {
+      "patterns": [
+        {
+          "comment": "Type arguments. This is complicated since we don't want to match things like foo < 123 || bar > baz",
+          "name": "meta.type-arguments.flowtype",
+          "begin": "\\s*+(<)(?=((?:(?>[^<>]+)|<\\g<-1>>)*)>)",
+          "end": "\\s*(>)",
+          "endCaptures": {
+            "1": { "name": "punctuation.flowtype" }
+          },
+          "beginCaptures": {
+            "1": { "name": "punctuation.flowtype" }
+          },
+          "patterns": [
+            {
+              "include": "#flowtype-parse-types"
+            },
+            {
+              "include": "#literal-comma"
+            }
+          ]
+        }
+      ]
+    },
     "square-brackets": {
       "patterns": [
         {
@@ -2146,6 +2170,8 @@
           "include": "#literal-keywords"
         },
         {
+          "comment": "A new expression with no type params or arguments, like new Foo()",
+          "name": "meta.new-class.without-arguments.js",
           "match": "(?<!\\.)\\s*+(\\bnew\\b)\\s*+((\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?(\\()\\s*+(\\)))",
           "captures": {
             "1": {
@@ -2172,7 +2198,24 @@
           }
         },
         {
-          "begin": "(?<!\\.)\\s*+(\\bnew\\b)\\s*+((\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?(?=\\())",
+          "comment": "A new expression with type params and no arguments, like new Foo<string>()",
+          "name": "meta.new-class.without-arguments.js",
+          "begin": "(?<!\\.)\\s*+(\\bnew\\b)\\s*+((\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?\\s*+(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)\\s*+(\\()\\s*+(\\))))",
+          "end": "(?=.)",
+          "applyEndPatternLast": 1,
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.new.js" },
+            "2": { "name": "meta.function-call.without-arguments.js" },
+            "3": { "name": "keyword.operator.private.js" },
+            "4": { "name": "entity.name.type.instance.js" },
+            "5": { "name": "keyword.operator.existential.js" }
+          },
+          "patterns": [{ "include": "#type-argument-brackets" }, { "include": "#round-brackets" }]
+        },
+        {
+          "comment": "A new expression with arguments and maybe type params, like new Foo<string>(123)",
+          "name": "meta.new-class.with-arguments.js",
+          "begin": "(?<!\\.)\\s*+(\\bnew\\b)\\s*+((\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?\\s*+(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\())",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -2194,6 +2237,9 @@
           },
           "patterns": [
             {
+              "include": "#type-argument-brackets"
+            },
+            {
               "include": "#round-brackets"
             }
           ]
@@ -2202,6 +2248,7 @@
           "include": "#literal-operators"
         },
         {
+          "comment": "A call expression with no type params or arguments, like foo()",
           "name": "meta.function-call.without-arguments.js",
           "match": "(?<!\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?(\\()\\s*+(\\))",
           "captures": {
@@ -2223,9 +2270,22 @@
           }
         },
         {
-          "comment": "maybe in array form e.g. foo[bar]()",
+          "comment": "A call expression with type params and no arguments, like foo<string>()",
           "name": "meta.function-call.without-arguments.js",
-          "begin": "(?<!\\.)\\s*+((\\bnew\\b)*)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)(?=\\s*(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*+\\(\\s*+\\))",
+          "begin": "(?<!\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?\\s*+(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)\\s*+(\\()\\s*+(\\)))",
+          "end": "(?=.)",
+          "applyEndPatternLast": 1,
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.private.js" },
+            "2": { "name": "entity.name.function.js" },
+            "3": { "name": "keyword.operator.existential.js" }
+          },
+          "patterns": [{ "include": "#type-argument-brackets" }, { "include": "#round-brackets" }]
+        },
+        {
+          "comment": "maybe in array form e.g. foo[bar]() or foo[bar]<string>()",
+          "name": "meta.function-call.without-arguments.js",
+          "begin": "(?<!\\.)\\s*+((\\bnew\\b)*)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)(?=\\s*(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*+(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\(\\s*+\\))",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -2244,13 +2304,17 @@
               "include": "#square-brackets"
             },
             {
+              "include": "#type-argument-brackets"
+            },
+            {
               "include": "#round-brackets"
             }
           ]
         },
         {
+          "comment": "A call expression with arguments and maybe type params, like foo(123) or foo<string>(123)",
           "name": "meta.function-call.with-arguments.js",
-          "begin": "(?<!\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?(?=\\()",
+          "begin": "(?<!\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(\\?\\.)?\\s*+(?=(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\()",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -2266,14 +2330,17 @@
           },
           "patterns": [
             {
+              "include": "#type-argument-brackets"
+            },
+            {
               "include": "#round-brackets"
             }
           ]
         },
         {
-          "comment": "maybe in array form e.g. foo[bar]()",
-          "name": "meta.function-call.without-arguments.js",
-          "begin": "(?<!\\.)\\s*+((\\bnew\\b)*)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*+\\()",
+          "comment": "maybe in array form e.g. foo[bar](123)",
+          "name": "meta.function-call.with-arguments.js",
+          "begin": "(?<!\\.)\\s*+((\\bnew\\b)*)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\g<-1>)*\\])\\s*+(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\()",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -2290,6 +2357,9 @@
           "patterns": [
             {
               "include": "#square-brackets"
+            },
+            {
+              "include": "#type-argument-brackets"
             },
             {
               "include": "#round-brackets"
@@ -2704,7 +2774,7 @@
         {
           "name": "meta.method-call.without-arguments.js",
           "comment": "e.g CONSTNAME.method() or CONST.method[p]()",
-          "begin": "\\s*+(\\#?)((?:[\\p{Lu}])(?:[$_\\p{Lu}\\p{Nd}])*+)\\s*+(?:(\\?\\.)|(\\.))\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+(\\(\\s*+\\)))",
+          "begin": "\\s*+(\\#?)((?:[\\p{Lu}])(?:[$_\\p{Lu}\\p{Nd}])*+)\\s*+(?:(\\?\\.)|(\\.))\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+(\\(\\s*+\\)))",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -2730,6 +2800,9 @@
           "patterns": [
             {
               "include": "#square-brackets"
+            },
+            {
+              "include": "#type-argument-brackets"
             },
             {
               "include": "#round-brackets"
@@ -2774,7 +2847,7 @@
         {
           "name": "meta.method-call.with-arguments.js",
           "comment": "e.g CONSTNAME.method()",
-          "begin": "\\s*+(\\#?)((?:[\\p{Lu}])(?:[$_\\p{Lu}\\p{Nd}])*+)\\s*+(?:(\\?\\.)|(\\.))\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+\\()",
+          "begin": "\\s*+(\\#?)((?:[\\p{Lu}])(?:[$_\\p{Lu}\\p{Nd}])*+)\\s*+(?:(\\?\\.)|(\\.))\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\()",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -2802,6 +2875,9 @@
               "include": "#square-brackets"
             },
             {
+              "include": "#type-argument-brackets"
+            },
+            {
               "include": "#round-brackets"
             }
           ]
@@ -2809,7 +2885,7 @@
         {
           "name": "meta.method-call.with-arguments.js",
           "comment": "e.g Abc.aaa()",
-          "begin": "\\s*+(\\#?)((?:[\\p{Lu}])(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?:(\\?\\.)|(\\.))\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+\\()",
+          "begin": "\\s*+(\\#?)((?:[\\p{Lu}])(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?:(\\?\\.)|(\\.))\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\()",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -2835,13 +2911,16 @@
           "patterns": [
             {
               "include": "#round-brackets"
+            },
+            {
+              "include": "#type-argument-brackets"
             }
           ]
         },
         {
           "name": "meta.method-call.without-arguments.js",
           "comment": "e.g .aaa()",
-          "begin": "(?<=\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+(\\(\\s*+\\)))",
+          "begin": "(?<=\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+(\\(\\s*+\\)))",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -2860,6 +2939,9 @@
               "include": "#square-brackets"
             },
             {
+              "include": "#type-argument-brackets"
+            },
+            {
               "include": "#round-brackets"
             }
           ]
@@ -2867,7 +2949,7 @@
         {
           "name": "meta.method-call.with-arguments.js",
           "comment": "e.g .aaa()",
-          "begin": "(?<=\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+\\()",
+          "begin": "(?<=\\.)\\s*+(\\#?)((?:[$_\\p{L}\\p{Nl}]|\\\\u\\h{4}|\\\\u{\\h+})(?:[$_\\p{L}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Nl}\\p{Pc}\\x{200C}\\x{200D}]|\\\\u\\h{4}|\\\\u{\\h+})*+)\\s*+(?=(\\[(?:(?>[^\\[\\]]+)|\\\\g<-1>)*\\])?+\\s*+(<(?:(?>[^<>]+)|\\g<-1>)*>)?\\s*+\\()",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
@@ -2881,6 +2963,9 @@
           "patterns": [
             {
               "include": "#square-brackets"
+            },
+            {
+              "include": "#type-argument-brackets"
             },
             {
               "include": "#round-brackets"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1992,6 +1992,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -2196,6 +2202,15 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "oniguruma": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.2.0.tgz",
+      "integrity": "sha512-bh+ZLdykY1sdIx8jBp2zpLbVFDBc3XmKH4Ceo2lijNaN1WhEqtnpqFlmtCbRuDB17nJ58RAUStVwfW8e8uEbnA==",
+      "dev": true,
+      "requires": {
+        "nan": "^2.14.0"
       }
     },
     "p-finally": {
@@ -3254,6 +3269,56 @@
       "requires": {
         "http-proxy-agent": "^2.1.0",
         "https-proxy-agent": "^2.2.1"
+      }
+    },
+    "vscode-textmate": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-4.2.2.tgz",
+      "integrity": "sha512-1U4ih0E/KP1zNK/EbpUqyYtI7PY+Ccd2nDGTtiMR/UalLFnmaYkwoWhN1oI7B91ptBN8NdVwWuvyUnvJAulCUw==",
+      "dev": true,
+      "requires": {
+        "oniguruma": "^7.2.0"
+      }
+    },
+    "vscode-tmgrammar-test": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.0.5.tgz",
+      "integrity": "sha512-iK5OEahJ9RTWmscD16f7z/TAH32iW8GDvHFIktlySP8XJM/n6Pi2GOwayDTo/teF70cEW0uhIQfhGuBQ08lfpQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "commander": "^2.20.0",
+        "diff": "^4.0.1",
+        "glob": "^7.1.4",
+        "vscode-textmate": "^4.1.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "prettier:stdin": "prettier --single-quote --print-width 100 --trailing-comma all --write",
     "prettier": "npm run prettier:stdin -- '**/*.ts' '**/*.json'",
-    "test": "jest"
+    "test": "vscode-tmgrammar-test -s source.js -g grammars/Babel-Language.json -t 'tests/*.js'"
   },
   "repository": {
     "type": "git",
@@ -174,7 +174,8 @@
     "lint-staged": "^8.1.4",
     "prettier": "^1.16.4",
     "typescript": "^3.3.3",
-    "vscode": "^1.1.35"
+    "vscode": "^1.1.35",
+    "vscode-tmgrammar-test": "0.0.5"
   },
   "husky": {
     "hooks": {

--- a/tests/calls_with_type_args.js
+++ b/tests/calls_with_type_args.js
@@ -1,0 +1,363 @@
+// SYNTAX TEST "source.js"
+
+new MyInstance();
+// <-- meta.new-class.without-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^  meta.new-class.without-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.without-arguments.js
+//            ^^  meta.brace.round.js
+//              ^ punctuation.terminator.statement.js
+
+new MyInstance<string>();
+// <-- meta.new-class.without-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^  meta.new-class.without-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.without-arguments.js
+//            ^^^^^^^^ meta.type-arguments.flowtype
+//            ^ punctuation.flowtype
+//             ^^^^^^ support.type.builtin.primitive.flowtype
+//                   ^ punctuation.flowtype
+//                    ^^  meta.brace.round.js
+//                      ^ punctuation.terminator.statement.js
+
+new MyInstance < string > ();
+// <-- meta.new-class.without-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^  meta.new-class.without-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.without-arguments.js
+//             ^^^^^^^^^^ meta.type-arguments.flowtype
+//             ^        ^ punctuation.flowtype
+//               ^^^^^^ support.type.builtin.primitive.flowtype
+//                        ^^  meta.brace.round.js
+//                          ^ punctuation.terminator.statement.js
+
+new MyInstance<Baz<string>, number>();
+// <-- meta.new-class.without-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.new-class.without-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.without-arguments.js
+//            ^^^^^^^^^^^^^^^^^^^^^ meta.type-arguments.flowtype
+//            ^                   ^ punctuation.flowtype
+//             ^^^ support.type.class.flowtype
+//                ^      ^ punctuation.flowtype
+//                 ^^^^^^ support.type.builtin.primitive.flowtype
+//                        ^ meta.delimiter.comma.js
+//                          ^^^^^^ support.type.builtin.primitive.flowtype
+//                                 ^^  meta.brace.round.js
+//                                   ^ punctuation.terminator.statement.js
+
+new MyInstance("hi");
+// <-- meta.new-class.with-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^  meta.new-class.with-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.with-arguments.js
+//            ^  meta.brace.round.js
+//                 ^  meta.brace.round.js
+//                  ^ punctuation.terminator.statement.js
+
+new MyInstance<string>("hi");
+// <-- meta.new-class.with-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^  meta.new-class.with-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.with-arguments.js
+//            ^^^^^^^^ meta.type-arguments.flowtype
+//            ^ punctuation.flowtype
+//             ^^^^^^ support.type.builtin.primitive.flowtype
+//                   ^ punctuation.flowtype
+//                    ^  meta.brace.round.js
+//                         ^  meta.brace.round.js
+//                          ^ punctuation.terminator.statement.js
+
+new MyInstance < string > ("hi");
+// <-- meta.new-class.with-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^  meta.new-class.with-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.with-arguments.js
+//             ^^^^^^^^^^ meta.type-arguments.flowtype
+//             ^        ^ punctuation.flowtype
+//               ^^^^^^ support.type.builtin.primitive.flowtype
+//                        ^    ^ meta.brace.round.js
+//                              ^ punctuation.terminator.statement.js
+
+new MyInstance<Baz<string>, number>("hi");
+// <-- meta.new-class.with-arguments.js keyword.operator.new.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.new-class.with-arguments.js
+//  ^^^^^^^^^^ entity.name.type.instance.js
+//  ^^^^^^^^^^ meta.function-call.with-arguments.js
+//            ^^^^^^^^^^^^^^^^^^^^^ meta.type-arguments.flowtype
+//            ^                   ^ punctuation.flowtype
+//             ^^^ support.type.class.flowtype
+//                ^      ^ punctuation.flowtype
+//                 ^^^^^^ support.type.builtin.primitive.flowtype
+//                        ^ meta.delimiter.comma.js
+//                          ^^^^^^ support.type.builtin.primitive.flowtype
+//                                 ^    ^  meta.brace.round.js
+//                                       ^ punctuation.terminator.statement.js
+
+myFunction();
+// <-- meta.function-call.without-arguments.js
+//  ^^^^^^^^  meta.function-call.without-arguments.js
+//  ^^^^^^ entity.name.function.js
+//        ^^  meta.brace.round.js
+//          ^ punctuation.terminator.statement.js
+
+myFunction<string>();
+// <-- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//  ^^^^^^ entity.name.function.js
+//  ^^^^^^ meta.function-call.without-arguments.js
+//        ^^^^^^^^ meta.type-arguments.flowtype
+//        ^ punctuation.flowtype
+//         ^^^^^^ support.type.builtin.primitive.flowtype
+//               ^ punctuation.flowtype
+//                ^^  meta.brace.round.js
+//                  ^ punctuation.terminator.statement.js
+
+myFunction < string > ();
+// <-- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//  ^^^^^^ entity.name.function.js
+//  ^^^^^^ meta.function-call.without-arguments.js
+//         ^^^^^^^^^^ meta.type-arguments.flowtype
+//         ^        ^ punctuation.flowtype
+//           ^^^^^^ support.type.builtin.primitive.flowtype
+//                    ^^  meta.brace.round.js
+//                      ^ punctuation.terminator.statement.js
+
+myFunction<Baz<string>, number>();
+// <-- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//  ^^^^^^ entity.name.function.js
+//  ^^^^^^ meta.function-call.without-arguments.js
+//        ^^^^^^^^^^^^^^^^^^^^^ meta.type-arguments.flowtype
+//        ^                   ^ punctuation.flowtype
+//         ^^^ support.type.class.flowtype
+//            ^      ^ punctuation.flowtype
+//             ^^^^^^ support.type.builtin.primitive.flowtype
+//                    ^ meta.delimiter.comma.js
+//                      ^^^^^^ support.type.builtin.primitive.flowtype
+//                            ^ punctuation.flowtype
+//                             ^^  meta.brace.round.js
+//                               ^ punctuation.terminator.statement.js
+
+myObject.myProp();
+// <-- variable.other.object.js
+// ^^^^^ variable.other.object.js
+//       ^^^^^^^^  meta.method-call.without-arguments.js
+//      ^ keyword.operator.accessor.js
+//       ^^^^^^ entity.name.function.js
+//             ^^ meta.brace.round.js
+//               ^ punctuation.terminator.statement.js
+
+myObject.myProp<string>();
+// <-- variable.other.object.js
+// ^^^^^ variable.other.object.js
+//       ^^^^^^^^^^^^^^^^ meta.method-call.without-arguments.js
+//      ^ keyword.operator.accessor.js
+//       ^^^^^^ entity.name.function.js
+//             ^      ^ punctuation.flowtype
+//              ^^^^^^ support.type.builtin.primitive.flowtype
+//                     ^^ meta.brace.round.js
+//                       ^ punctuation.terminator.statement.js
+
+myObject.myProp < string > ();
+// <-- variable.other.object.js
+// ^^^^^ variable.other.object.js
+//       ^^^^^^^^^^^^^^^^^^^^  meta.method-call.without-arguments.js
+//      ^ keyword.operator.accessor.js
+//       ^^^^^^ entity.name.function.js
+//              ^        ^ punctuation.flowtype
+//                ^^^^^^ support.type.builtin.primitive.flowtype
+//                         ^^ meta.brace.round.js
+//                           ^ punctuation.terminator.statement.js
+
+myObject.myProp<Baz<string>, number>();
+// <-- variable.other.object.js
+// ^^^^^ variable.other.object.js
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.method-call.without-arguments.js
+//      ^ keyword.operator.accessor.js
+//       ^^^^^^ entity.name.function.js
+//             ^                   ^ punctuation.flowtype
+//              ^^^ support.type.class.flowtype
+//                 ^      ^ punctuation.flowtype
+//                  ^^^^^^ support.type.builtin.primitive.flowtype
+//                         ^ meta.delimiter.comma.js
+//                           ^^^^^^ support.type.builtin.primitive.flowtype
+//                                  ^^ meta.brace.round.js
+//                                    ^ punctuation.terminator.statement.js
+
+myObject[myProp]();
+// <-- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^^ meta.brace.round.js
+//                ^ punctuation.terminator.statement.js
+
+myObject[myProp]<string>();
+// <-- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^      ^ punctuation.flowtype
+//               ^^^^^^ support.type.builtin.primitive.flowtype
+//                      ^^ meta.brace.round.js
+//                        ^ punctuation.terminator.statement.js
+
+myObject[myProp] < string > ();
+// <-- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//               ^        ^ punctuation.flowtype
+//                 ^^^^^^ support.type.builtin.primitive.flowtype
+//                          ^^ meta.brace.round.js
+//                            ^ punctuation.terminator.statement.js
+
+myObject[myProp]<Baz<string>, number>();
+// <-- meta.function-call.without-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.without-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^                   ^ punctuation.flowtype
+//               ^^^ support.type.class.flowtype
+//                  ^      ^ punctuation.flowtype
+//                   ^^^^^^ support.type.builtin.primitive.flowtype
+//                          ^ meta.delimiter.comma.js
+//                            ^^^^^^ support.type.builtin.primitive.flowtype
+//                                   ^^ meta.brace.round.js
+//                                     ^ punctuation.terminator.statement.js
+
+myFunction("hi");
+// <-- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//  ^^^^^^ entity.name.function.js
+//        ^    ^  meta.brace.round.js
+//              ^ punctuation.terminator.statement.js
+
+myFunction<string>("hi");
+// <-- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//  ^^^^^^ entity.name.function.js
+//        ^      ^ punctuation.flowtype
+//         ^^^^^^ support.type.builtin.primitive.flowtype
+//                ^    ^  meta.brace.round.js
+//                      ^ punctuation.terminator.statement.js
+
+myFunction < string > ("hi");
+// <-- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//  ^^^^^^ entity.name.function.js
+//         ^        ^ punctuation.flowtype
+//           ^^^^^^ support.type.builtin.primitive.flowtype
+//                    ^    ^  meta.brace.round.js
+//                          ^ punctuation.terminator.statement.js
+
+myFunction<Baz<number>, string>("hi");
+// <-- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//  ^^^^^^ entity.name.function.js
+//        ^                   ^ punctuation.flowtype
+//         ^^^ support.type.class.flowtype
+//            ^      ^ punctuation.flowtype
+//             ^^^^^^ support.type.builtin.primitive.flowtype
+//                    ^ meta.delimiter.comma.js
+//                      ^^^^^^ support.type.builtin.primitive.flowtype
+//                             ^    ^  meta.brace.round.js
+//                                   ^ punctuation.terminator.statement.js
+
+myObject.myProp("hi");
+// <-- variable.other.object.js
+// ^^^^^ variable.other.object.js
+//       ^^^^^^^^^^^^ meta.method-call.with-arguments.js
+//      ^ keyword.operator.accessor.js
+//       ^^^^^^ entity.name.function.js
+//             ^    ^ meta.brace.round.js
+//                   ^ punctuation.terminator.statement.js
+
+myObject.myProp<string>("hi");
+// <-- variable.other.object.js
+// ^^^^^ variable.other.object.js
+//       ^^^^^^^^^^^^^^^^^^^^ meta.method-call.with-arguments.js
+//      ^ keyword.operator.accessor.js
+//       ^^^^^^ entity.name.function.js
+//             ^      ^ punctuation.flowtype
+//              ^^^^^^ support.type.builtin.primitive.flowtype
+//                     ^    ^ meta.brace.round.js
+//                           ^ punctuation.terminator.statement.js
+
+myObject.myProp < string > ("hi");
+// <-- variable.other.object.js
+// ^^^^^ variable.other.object.js
+//       ^^^^^^^^^^^^^^^^^^^^^^^^ meta.method-call.with-arguments.js
+//      ^ keyword.operator.accessor.js
+//       ^^^^^^ entity.name.function.js
+//              ^        ^ punctuation.flowtype
+//                ^^^^^^ support.type.builtin.primitive.flowtype
+//                         ^    ^ meta.brace.round.js
+//                               ^ punctuation.terminator.statement.js
+
+myObject.myProp<Baz<string>, number>("hi");
+// <-- variable.other.object.js
+// ^^^^^ variable.other.object.js
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.method-call.with-arguments.js
+//      ^ keyword.operator.accessor.js
+//       ^^^^^^ entity.name.function.js
+//             ^                   ^ punctuation.flowtype
+//              ^^^ support.type.class.flowtype
+//                 ^      ^ punctuation.flowtype
+//                  ^^^^^^ support.type.builtin.primitive.flowtype
+//                         ^ meta.delimiter.comma.js
+//                           ^^^^^^ support.type.builtin.primitive.flowtype
+//                                  ^    ^ meta.brace.round.js
+//                                        ^ punctuation.terminator.statement.js
+
+myObject[myProp]("hi");
+// <-- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^    ^ meta.brace.round.js
+//                    ^ punctuation.terminator.statement.js
+
+myObject[myProp]<string>("hi");
+// <-- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^      ^ punctuation.flowtype
+//               ^^^^^^ support.type.builtin.primitive.flowtype
+//                      ^    ^ meta.brace.round.js
+//                            ^ punctuation.terminator.statement.js
+
+myObject[myProp] < string > ("hi");
+// <-- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//               ^        ^ punctuation.flowtype
+//                 ^^^^^^ support.type.builtin.primitive.flowtype
+//                          ^    ^ meta.brace.round.js
+//                                ^ punctuation.terminator.statement.js
+
+myObject[myProp]<Baz<string>, number>("hi");
+// <-- meta.function-call.with-arguments.js
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.function-call.with-arguments.js
+//      ^      ^ meta.brace.square.js
+//       ^^^^^^ variable.other.readwrite.js
+//              ^                   ^ punctuation.flowtype
+//               ^^^ support.type.class.flowtype
+//                  ^      ^ punctuation.flowtype
+//                   ^^^^^^ support.type.builtin.primitive.flowtype
+//                          ^ meta.delimiter.comma.js
+//                            ^^^^^^ support.type.builtin.primitive.flowtype
+//                                   ^    ^ meta.brace.round.js
+//                                         ^ punctuation.terminator.statement.js
+
+new MyInstance<Baz<string>, number>() < 123;
+new MyInstance<Baz<string>, number>("hi") < 123;
+myFunction<Baz<string>, number>() < 123;
+myObject[myProp]<Baz<string>, number>() < 123;
+myObject<Baz<string>, number>("hi") < 123;
+
+// >> only:(source.js.jsx)


### PR DESCRIPTION
In Flow, you can call a function an explicitly specify the types for the generics. For example

```js
function foo<A, B>(a: A, b: B): void {}

foo<string, number>("hello", 123);
```

This PR attempts to update `vscode-language-babel` to support this syntax. It's a little complicated, since the grammar is somewhat ambiguous. For example, `foo < bar > (123)` is a valid expression in JavaScript, but Flow interprets it as a call expression with type parameters.

Fixes https://github.com/michaelgmcd/vscode-language-babel/issues/43
Similar to https://github.com/gandm/language-babel/pull/527, but adds `meta.method-call.*`