### PR TITLE
change all instances of `kewyword` to `keyword`

### DIFF
--- a/grammars/Babel-Language.json
+++ b/grammars/Babel-Language.json
@@ -4694,7 +4694,7 @@
           "match": "\\s*+(\\|)(?<!{\\|)(?!}|>)",
           "captures": {
             "1": {
-              "name": "kewyword.operator.union.flowtype"
+              "name": "keyword.operator.union.flowtype"
             }
           }
         },
@@ -4703,7 +4703,7 @@
           "match": "\\s*+(\\&)",
           "captures": {
             "1": {
-              "name": "kewyword.operator.intersection.flowtype"
+              "name": "keyword.operator.intersection.flowtype"
             }
           }
         },
@@ -4877,7 +4877,7 @@
           "match": "\\s*+(\\|)(?<!{\\|)(?!}|>)",
           "captures": {
             "1": {
-              "name": "kewyword.operator.union.flowtype"
+              "name": "keyword.operator.union.flowtype"
             }
           }
         },
@@ -4886,7 +4886,7 @@
           "match": "\\s*+(\\&)",
           "captures": {
             "1": {
-              "name": "kewyword.operator.intersection.flowtype"
+              "name": "keyword.operator.intersection.flowtype"
             }
           }
         },
@@ -4895,7 +4895,7 @@
           "match": "\\s*+(\\*)(?!/([^\\*]|$))",
           "captures": {
             "1": {
-              "name": "kewyword.operator.existential.flowtype"
+              "name": "keyword.operator.existential.flowtype"
             }
           }
         },
@@ -5132,10 +5132,10 @@
           "match": "((\\|)(?={|))|(\\s*(\\|)(?=}))",
           "captures": {
             "1": {
-              "name": "kewyword.operator.only.flowtype"
+              "name": "keyword.operator.only.flowtype"
             },
             "4": {
-              "name": "kewyword.operator.only.flowtype"
+              "name": "keyword.operator.only.flowtype"
             }
           }
         },


### PR DESCRIPTION
Searching all of GitHub code for the typo "`kewyword`" yields [1072 results](https://github.com/search?q=kewyword&type=Code). A decent number of them are related to the long legacy of this particular Babel syntax, but it also seems like an all-around popular typo to commit :smile:.

Making this change will break VS Code themes like [mine](https://marketplace.visualstudio.com/items?itemName=dustypomerleau.yarra-valley), that have intentionally reproduced the typo to get the colors they want, but in the long run will give better highlighting for everyone.

Thanks to all the contributors for this awesome extension.