### PR TITLE
Add support for stylesheet in astroturf

### DIFF
--- a/grammars/Babel-Language.json
+++ b/grammars/Babel-Language.json
@@ -1545,7 +1545,7 @@
         {
           "comment": "Styled CSS tags",
           "contentName": "source.inside-js.css.styled",
-          "begin": "\\s*+(?:(?:\\b(css|injectGlobal|keyframes|createGlobalStyle)\\b)|(?:(\\bstyled)(?:(?:(\\?\\.)|(\\.))\\s*(\\w+)))|(/\\* CSS \\*/))\\s*((`))",
+          "begin": "\\s*+(?:(?:\\b(css|injectGlobal|keyframes|createGlobalStyle|stylesheet)\\b)|(?:(\\bstyled)(?:(?:(\\?\\.)|(\\.))\\s*(\\w+)))|(/\\* CSS \\*/))\\s*((`))",
           "end": "\\s*((`))",
           "beginCaptures": {
             "1": {


### PR DESCRIPTION
New version of [astroturf](https://github.com/4Catalyzer/astroturf) introduces a new [`stylesheet`](https://github.com/4Catalyzer/astroturf/blob/master/www/src/pages/migration.mdx) function which currently doesn't support by this extension. This change adds support for it. Similar to #37 

<img width="348" alt="Screenshot 2021-04-03 at 22 28 34" src="https://user-images.githubusercontent.com/1177226/113489258-ee2b0200-94cb-11eb-938a-0bf029f3eadf.png">

