### PR TITLE
fix: add support for `createGlobalStyles` as CSS

### DIFF
--- a/grammars/Babel-Language.json
+++ b/grammars/Babel-Language.json
@@ -1545,7 +1545,7 @@
         {
           "comment": "Styled CSS tags",
           "contentName": "source.inside-js.css.styled",
-          "begin": "\\s*+(?:(?:\\b(css|injectGlobal|keyframes|createGlobalStyle|stylesheet)\\b)|(?:(\\bstyled)(?:(?:(\\?\\.)|(\\.))\\s*(\\w+)))|(/\\* CSS \\*/))\\s*((`))",
+          "begin": "\\s*+(?:(?:\\b(css|injectGlobal|keyframes|createGlobalStyles?|stylesheet)\\b)|(?:(\\bstyled)(?:(?:(\\?\\.)|(\\.))\\s*(\\w+)))|(/\\* CSS \\*/))\\s*((`))",
           "end": "\\s*((`))",
           "beginCaptures": {
             "1": {


### PR DESCRIPTION
Libraries like [`goober`](https://goober.js.org/api/createGlobalStyles) has named their global styles function `createGlobalStyles`, so this PR adds an optional `s` to the regex the check whether it is `createGlobalStyle` or `createGlobalStyles`