### PR TITLE
fix typo in `declare class` scope

### DIFF
--- a/grammars/Babel-Language.json
+++ b/grammars/Babel-Language.json
@@ -5487,7 +5487,7 @@
               "name": "keyword.other.declare.flowtype"
             },
             "2": {
-              "name": "keyword.constrol.module.flowtype"
+              "name": "keyword.control.module.flowtype"
             },
             "3": {
               "name": "storage.type.class.flowtype"


### PR DESCRIPTION
`constrol` -> `control`